### PR TITLE
2.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.DS_Store
 /target
 .DS_Store
+
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -6,25 +6,26 @@
 	<artifactId>lexevsServiceTests</artifactId>
 	<version>0.0.1-SNAPSHOT</version>
 	<packaging>jar</packaging>
-
 	<name>lexevsServiceTests</name>
 	<url>http://maven.apache.org</url>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<java.version>1.8</java.version>
 	</properties>
 
 	<dependencies>
+<!-- https://mvnrepository.com/artifact/io.rest-assured/rest-assured -->
 		<dependency>
-			<groupId>io.rest-assured</groupId>
-			<artifactId>rest-assured</artifactId>
-			<version>4.0.0</version>
-			<scope>test</scope>
+    		<groupId>io.rest-assured</groupId>
+    		<artifactId>rest-assured</artifactId>
+    		<version>5.2.0</version>
+    		<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
-			<version>1.3</version>
+			<artifactId>hamcrest</artifactId>
+			<version>2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/src/test/java/lexevs/service/unitTests/lexevsServiceTests/LexevsRestTestRunnerTest.java
+++ b/src/test/java/lexevs/service/unitTests/lexevsServiceTests/LexevsRestTestRunnerTest.java
@@ -18,12 +18,12 @@ public class LexevsRestTestRunnerTest extends TestCase
 {
 	// These variables should be pulled from a properties file.
 	
-	public static final String BASE_URL = "https://lexevs65cts2-qa.nci.nih.gov/";
+	public static final String BASE_URL = "https://lexevscts2-dev.nci.nih.gov/";
 	public static final String BASE_PATH = "/lexevscts2";
 	
 	public static final String LEXEVS_SERVICE_VERSION = "1.3.9.FINAL";
 	
-	public static final String THESAURUS_VERSION_NUMBER = "22.01e";
+	public static final String THESAURUS_VERSION_NUMBER = "22.08e";
 	public static final String THESAURUS = "NCI_Thesaurus";
 	public static final String THESAURUS_VERSION = THESAURUS + "-" + THESAURUS_VERSION_NUMBER; 
 	
@@ -79,14 +79,14 @@ public class LexevsRestTestRunnerTest extends TestCase
 		
 		RestAssured.
 			when().
-				get("/codesystemversions?format=json").
+				get("/codesystemversions?format=json&maxtoreturn=1000").
 			then().
 				assertThat().
 					statusCode(200).
 					body("CodeSystemVersionCatalogEntryDirectory.complete", hasToString("COMPLETE"),
   						 "CodeSystemVersionCatalogEntryDirectory.numEntries", greaterThanOrEqualTo(20),
-  						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName == 'MedDRA-22_1' }.versionOf.content", equalTo("MedDRA"),
-  						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName == 'ChEBI-v208' }.versionOf.content", equalTo("ChEBI"),
+  						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName == 'MDR-22_1' }.versionOf.content", equalTo("MDR"),
+  						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName == 'ChEBI-v213' }.versionOf.content", equalTo("ChEBI"),
   						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName == 'NDFRT-February2018' }.versionOf.content", equalTo("NDFRT"));
 	}
 	
@@ -120,7 +120,7 @@ public class LexevsRestTestRunnerTest extends TestCase
   						 "CodeSystemVersionCatalogEntryDirectory.numEntries", equalTo(5),
   						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName == 'UMLS_SemNet-3.2' }.versionOf.content", equalTo("UMLS_SemNet"),
   						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName == '" + THESAURUS_VERSION +"' }.versionOf.content", equalTo("NCI_Thesaurus"),
-  						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName == 'NCI Metathesaurus-202108' }.versionOf.content", equalTo("NCI Metathesaurus"));
+  						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName == 'NCI Metathesaurus-202208' }.versionOf.content", equalTo("NCI Metathesaurus"));
 	}
 	
 	//*********************************************************************
@@ -392,9 +392,9 @@ public class LexevsRestTestRunnerTest extends TestCase
 					statusCode(200).					
 					body("EntityDirectory.complete", is("COMPLETE"),
 						 "EntityDirectory.numEntries", is(44),
-						 "EntityDirectory.entry.find { it.name.name == '10009269' }.name.namespace", equalTo("MedDRA"),
-						 "EntityDirectory.entry.find { it.name.name == '10009276' }.name.namespace", equalTo("MedDRA"),
-						 "EntityDirectory.entry.find { it.name.name == '10009264' }.name.namespace", equalTo("MedDRA"));
+						 "EntityDirectory.entry.find { it.name.name == '10009269' }.name.namespace", equalTo("MDR"),
+						 "EntityDirectory.entry.find { it.name.name == '10009276' }.name.namespace", equalTo("MDR"),
+						 "EntityDirectory.entry.find { it.name.name == '10009264' }.name.namespace", equalTo("MDR"));
 	}
 	  	 
 	//*********************************************************************
@@ -474,7 +474,7 @@ public class LexevsRestTestRunnerTest extends TestCase
 		
 		RestAssured.
 			when().
-				get("/entities?matchvalue=heart&filtercomponent=resourceSynopsis&matchalgorithm=luceneQuery&format=json").
+				get("/entities?matchvalue=heart&filtercomponent=resourceSynopsis&matchalgorithm=luceneQuery&format=json&maxtoreturn=1000").
 			then().
 				assertThat().
 					statusCode(200).
@@ -612,16 +612,16 @@ public class LexevsRestTestRunnerTest extends TestCase
 				assertThat().
 					statusCode(200).
 					body("AssociationDirectory.complete", hasToString("COMPLETE"),
-  						 "AssociationDirectory.numEntries", equalTo(13),
+  						 "AssociationDirectory.numEntries", equalTo(16),
   						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C875' }.subject.name", equalTo("C875"),
   						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C875' }.subject.namespace", equalTo("ncit"),
   						   						 
-  						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C157711' }.subject.name", equalTo("C157711"),
- 						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C157711' }.predicate.name", equalTo("Concept_In_Subset"),
- 						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C157711' }.target.entity.namespace", equalTo("ncit"),
-						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C157711' }.target.entity.name", equalTo("C174019"),
-						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C157711' }.assertedBy.codeSystem.content", equalTo("NCI_Thesaurus"),
-						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C157711' }.assertedBy.codeSystem.uri", equalTo("http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#"));
+  						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C186328' }.subject.name", equalTo("C186328"),
+ 						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C186328' }.predicate.name", equalTo("Concept_In_Subset"),
+ 						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C186328' }.target.entity.namespace", equalTo("ncit"),
+						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C186328' }.target.entity.name", equalTo("C174019"),
+						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C186328' }.assertedBy.codeSystem.content", equalTo("NCI_Thesaurus"),
+						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C186328' }.assertedBy.codeSystem.uri", equalTo("http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#"));
 	}
 	
 	
@@ -632,7 +632,7 @@ public class LexevsRestTestRunnerTest extends TestCase
 		
 		RestAssured.
 			when().
-				get("/codesystem/NCI_Thesaurus/version/" + THESAURUS_VERSION_NUMBER + "/entity/ncit:C128784/targetof?format=json").
+				get("/codesystem/NCI_Thesaurus/version/" + THESAURUS_VERSION_NUMBER + "/entity/ncit:C128784/targetof?format=json&maxtoreturn=1000").
 			then().
 				assertThat().
 					statusCode(200).
@@ -662,15 +662,15 @@ public class LexevsRestTestRunnerTest extends TestCase
 				assertThat().
 					statusCode(200).
 					body("ValueSetCatalogEntryDirectory.complete", hasToString("PARTIAL"),
-  						 "ValueSetCatalogEntryDirectory.numEntries", equalTo(1000),
+  						 "ValueSetCatalogEntryDirectory.numEntries", equalTo(50),
   						 
   						 "ValueSetCatalogEntryDirectory.entry.find { it.valueSetName == 'NCIt Neoplasm Core Terminology' }.about", equalTo("http://evs.nci.nih.gov/valueset/C126659"),
   						 "ValueSetCatalogEntryDirectory.entry.find { it.valueSetName == 'NCIt Neoplasm Core Terminology' }.currentDefinition.valueSetDefinition.content", equalTo("ed0a1ca6"),
   					  	 "ValueSetCatalogEntryDirectory.entry.find { it.valueSetName == 'NCIt Neoplasm Core Terminology' }.currentDefinition.valueSetDefinition.uri", equalTo("http://evs.nci.nih.gov/valueset/C126659"),
   						 
-		                 "ValueSetCatalogEntryDirectory.entry.find { it.valueSetName == 'CDISC Clinical Classification AIMS Test Code Terminology' }.about", equalTo("http://evs.nci.nih.gov/valueset/CDISC/C101805"),
-			             "ValueSetCatalogEntryDirectory.entry.find { it.valueSetName == 'CDISC Clinical Classification AIMS Test Code Terminology' }.currentDefinition.valueSetDefinition.content", equalTo("d97ef78d"),
-		  	             "ValueSetCatalogEntryDirectory.entry.find { it.valueSetName == 'CDISC Clinical Classification AIMS Test Code Terminology' }.currentDefinition.valueSetDefinition.uri", equalTo("http://evs.nci.nih.gov/valueset/CDISC/C101805"));
+		                 "ValueSetCatalogEntryDirectory.entry.find { it.valueSetName == 'ACC/AHA EHR Terminology' }.about", equalTo("http://evs.nci.nih.gov/valueset/ACC/AHA/C167405"),
+			             "ValueSetCatalogEntryDirectory.entry.find { it.valueSetName == 'ACC/AHA EHR Terminology' }.currentDefinition.valueSetDefinition.content", equalTo("61b982e4"),
+		  	             "ValueSetCatalogEntryDirectory.entry.find { it.valueSetName == 'ACC/AHA EHR Terminology' }.currentDefinition.valueSetDefinition.uri", equalTo("http://evs.nci.nih.gov/valueset/ACC/AHA/C167405"));
 	 }
 	
 	//*********************************************************************

--- a/src/test/java/lexevs/service/unitTests/lexevsServiceTests/LexevsRestTestRunnerTest.java
+++ b/src/test/java/lexevs/service/unitTests/lexevsServiceTests/LexevsRestTestRunnerTest.java
@@ -18,12 +18,12 @@ public class LexevsRestTestRunnerTest extends TestCase
 {
 	// These variables should be pulled from a properties file.
 	
-	public static final String BASE_URL = "https://lexevscts2-dev.nci.nih.gov/";
+	public static final String BASE_URL = "https://lexevscts2-qa.nci.nih.gov/";
 	public static final String BASE_PATH = "/lexevscts2";
 	
-	public static final String LEXEVS_SERVICE_VERSION = "2.0.0.FINAL";
+	public static final String LEXEVS_SERVICE_VERSION = "2.1.RC3";
 	
-	public static final String THESAURUS_VERSION_NUMBER = "22.08e";
+	public static final String THESAURUS_VERSION_NUMBER = "22.12d";
 	public static final String THESAURUS = "NCI_Thesaurus";
 	public static final String THESAURUS_VERSION = THESAURUS + "-" + THESAURUS_VERSION_NUMBER; 
 	

--- a/src/test/java/lexevs/service/unitTests/lexevsServiceTests/LexevsRestTestRunnerTest.java
+++ b/src/test/java/lexevs/service/unitTests/lexevsServiceTests/LexevsRestTestRunnerTest.java
@@ -21,9 +21,11 @@ public class LexevsRestTestRunnerTest extends TestCase
 	public static final String BASE_URL = "https://lexevscts2-qa.nci.nih.gov/";
 	public static final String BASE_PATH = "/lexevscts2";
 	
-	public static final String LEXEVS_SERVICE_VERSION = "2.1.RC3";
+	public static final String LEXEVS_SERVICE_VERSION = "2.1.0";
 	
 	public static final String THESAURUS_VERSION_NUMBER = "22.12d";
+
+	public static final String CHEBI_VERSION="217";
 	public static final String THESAURUS = "NCI_Thesaurus";
 	public static final String THESAURUS_VERSION = THESAURUS + "-" + THESAURUS_VERSION_NUMBER; 
 	
@@ -67,8 +69,8 @@ public class LexevsRestTestRunnerTest extends TestCase
 				statusCode(200).
 					body("BaseService.serviceName", hasToString("CTS2 Development Framework RESTWebApp"),
 					 "BaseService.serviceVersion", hasToString(LEXEVS_SERVICE_VERSION),					 
-					 "BaseService.supportedProfile.find { it.structuralProfile == 'SP_ENTITY_DESCRIPTION' }.functionalProfile.content", hasItems("FP_READ"),
-					 "BaseService.supportedProfile.find { it.structuralProfile == 'SP_CODE_SYSTEM_VERSION' }.functionalProfile.content", hasItems("FP_QUERY"),
+					 "BaseService.supportedProfile.find { it.structuralProfile == 'SP_ENTITY_DESCRIPTION' }.functionalProfile.content", hasItems("FP_QUERY"),
+					 "BaseService.supportedProfile.find { it.structuralProfile == 'SP_CODE_SYSTEM_VERSION' }.functionalProfile.content", hasItems("FP_READ"),
 					 "BaseService.supportedProfile.find { it.structuralProfile == 'SP_ASSOCIATION' }.functionalProfile.content", hasItems("FP_QUERY"));
 	}
 	
@@ -76,7 +78,7 @@ public class LexevsRestTestRunnerTest extends TestCase
 	// codeSystemVersion
 	//*********************************************************************
 	public final void test_codeSystemVersion_call() {
-		
+		String chebi = "ChEBI-v" + CHEBI_VERSION;
 		RestAssured.
 			when().
 				get("/codesystemversions?format=json&maxtoreturn=1000").
@@ -86,7 +88,7 @@ public class LexevsRestTestRunnerTest extends TestCase
 					body("CodeSystemVersionCatalogEntryDirectory.complete", hasToString("COMPLETE"),
   						 "CodeSystemVersionCatalogEntryDirectory.numEntries", greaterThanOrEqualTo(20),
   						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName == 'MedDRA-22_1' }.versionOf.content", equalTo("MedDRA"),
-  						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName == 'ChEBI-v213' }.versionOf.content", equalTo("ChEBI"),
+  						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName =='"+ chebi+"' }.versionOf.content", equalTo("ChEBI"),
   						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName == 'NDFRT-February2018' }.versionOf.content", equalTo("NDFRT"));
 	}
 	
@@ -437,17 +439,17 @@ public class LexevsRestTestRunnerTest extends TestCase
 	//*********************************************************************
 	// entities - search (all)
 	//*********************************************************************
-	public final void test_entities_search_all_call() {
-		
-		RestAssured.
-			when().
-				get("/entities?maxtoreturn=50&format=json").
-			then().
-				assertThat().
-					statusCode(200).
-					body("EntityDirectory.complete", hasToString("PARTIAL"),
-  						 "EntityDirectory.numEntries", equalTo(50));
-	}
+//	public final void test_entities_search_all_call() {
+//
+//		RestAssured.
+//			when().
+//				get("/entities?maxtoreturn=50&format=json").
+//			then().
+//				assertThat().
+//					statusCode(200).
+//					body("EntityDirectory.complete", hasToString("PARTIAL"),
+//  						 "EntityDirectory.numEntries", equalTo(50));
+//	}
 	
 	//*********************************************************************
 	// entities - search all for non-existing value
@@ -603,7 +605,7 @@ public class LexevsRestTestRunnerTest extends TestCase
 	//*********************************************************************
 	// associations - subjectof 
 	//*********************************************************************
-	public final void test_assoacitions_subjectof_call() {
+	public final void test_associations_subjectof_call() {
 		
 		RestAssured.
 			when().
@@ -619,7 +621,7 @@ public class LexevsRestTestRunnerTest extends TestCase
   						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C186328' }.subject.name", equalTo("C186328"),
  						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C186328' }.predicate.name", equalTo("Concept_In_Subset"),
  						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C186328' }.target.entity.namespace", equalTo("ncit"),
-						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C186328' }.target.entity.name", equalTo("C174019"),
+						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C186328' }.target.entity.name", equalTo("C173234"),
 						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C186328' }.assertedBy.codeSystem.content", equalTo("NCI_Thesaurus"),
 						 "AssociationDirectory.entry.find { it.subject.uri == 'http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#C186328' }.assertedBy.codeSystem.uri", equalTo("http://ncicb.nci.nih.gov/xml/owl/EVS/Thesaurus.owl#"));
 	}
@@ -628,7 +630,7 @@ public class LexevsRestTestRunnerTest extends TestCase
 	//*********************************************************************
 	// associations - targetof 
 	//*********************************************************************
-	public final void test_assoacitions_targetof_call() {
+	public final void test_associations_targetof_call() {
 		
 		RestAssured.
 			when().

--- a/src/test/java/lexevs/service/unitTests/lexevsServiceTests/LexevsRestTestRunnerTest.java
+++ b/src/test/java/lexevs/service/unitTests/lexevsServiceTests/LexevsRestTestRunnerTest.java
@@ -21,7 +21,7 @@ public class LexevsRestTestRunnerTest extends TestCase
 	public static final String BASE_URL = "https://lexevscts2-dev.nci.nih.gov/";
 	public static final String BASE_PATH = "/lexevscts2";
 	
-	public static final String LEXEVS_SERVICE_VERSION = "1.3.9.FINAL";
+	public static final String LEXEVS_SERVICE_VERSION = "2.0.0.FINAL";
 	
 	public static final String THESAURUS_VERSION_NUMBER = "22.08e";
 	public static final String THESAURUS = "NCI_Thesaurus";
@@ -67,8 +67,8 @@ public class LexevsRestTestRunnerTest extends TestCase
 				statusCode(200).
 					body("BaseService.serviceName", hasToString("CTS2 Development Framework RESTWebApp"),
 					 "BaseService.serviceVersion", hasToString(LEXEVS_SERVICE_VERSION),					 
-					 "BaseService.supportedProfile.find { it.structuralProfile == 'SP_ENTITY_DESCRIPTION' }.functionalProfile.content", hasItems("FP_QUERY"),
-					 "BaseService.supportedProfile.find { it.structuralProfile == 'SP_CODE_SYSTEM_VERSION' }.functionalProfile.content", hasItems("FP_READ"),
+					 "BaseService.supportedProfile.find { it.structuralProfile == 'SP_ENTITY_DESCRIPTION' }.functionalProfile.content", hasItems("FP_READ"),
+					 "BaseService.supportedProfile.find { it.structuralProfile == 'SP_CODE_SYSTEM_VERSION' }.functionalProfile.content", hasItems("FP_QUERY"),
 					 "BaseService.supportedProfile.find { it.structuralProfile == 'SP_ASSOCIATION' }.functionalProfile.content", hasItems("FP_QUERY"));
 	}
 	
@@ -85,7 +85,7 @@ public class LexevsRestTestRunnerTest extends TestCase
 					statusCode(200).
 					body("CodeSystemVersionCatalogEntryDirectory.complete", hasToString("COMPLETE"),
   						 "CodeSystemVersionCatalogEntryDirectory.numEntries", greaterThanOrEqualTo(20),
-  						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName == 'MDR-22_1' }.versionOf.content", equalTo("MDR"),
+  						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName == 'MedDRA-22_1' }.versionOf.content", equalTo("MedDRA"),
   						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName == 'ChEBI-v213' }.versionOf.content", equalTo("ChEBI"),
   						 "CodeSystemVersionCatalogEntryDirectory.entry.find { it.codeSystemVersionName == 'NDFRT-February2018' }.versionOf.content", equalTo("NDFRT"));
 	}
@@ -392,9 +392,9 @@ public class LexevsRestTestRunnerTest extends TestCase
 					statusCode(200).					
 					body("EntityDirectory.complete", is("COMPLETE"),
 						 "EntityDirectory.numEntries", is(44),
-						 "EntityDirectory.entry.find { it.name.name == '10009269' }.name.namespace", equalTo("MDR"),
-						 "EntityDirectory.entry.find { it.name.name == '10009276' }.name.namespace", equalTo("MDR"),
-						 "EntityDirectory.entry.find { it.name.name == '10009264' }.name.namespace", equalTo("MDR"));
+						 "EntityDirectory.entry.find { it.name.name == '10009269' }.name.namespace", equalTo("MedDRA"),
+						 "EntityDirectory.entry.find { it.name.name == '10009276' }.name.namespace", equalTo("MedDRA"),
+						 "EntityDirectory.entry.find { it.name.name == '10009264' }.name.namespace", equalTo("MedDRA"));
 	}
 	  	 
 	//*********************************************************************
@@ -496,7 +496,7 @@ public class LexevsRestTestRunnerTest extends TestCase
 				assertThat().
 					statusCode(200).
 					body("EntityDirectory.complete", hasToString("COMPLETE"),
-  						 "EntityDirectory.numEntries", equalTo(38),
+  						 "EntityDirectory.numEntries", equalTo(42),
   						 "EntityDirectory.entry[1].name.name", equalTo("10019277"),
   						 "EntityDirectory.entry[1].name.namespace", equalTo("MedDRA"));
 	}

--- a/src/test/resources/config.properties
+++ b/src/test/resources/config.properties
@@ -1,6 +1,6 @@
 # CTS2/REST URL
 #BASE_URL=https://lexevs65cts2.nci.nih.gov
-BASE_URL=https://lexevs65cts2-qa.nci.nih.gov
+BASE_URL=https://lexevs65cts2-dev.nci.nih.gov
 BASE_PATH=/lexevscts2
 
 # Version of the CTS2 service


### PR DESCRIPTION
Here are the changes made:
At the top, just below where you enter the NCI_Thesaurus version, there is now a variable to set the ChEBI version.

The FP_QUERY and FP_READ checks were reversed. This has been fixed.

The associations test for C186328 had been updated for new data.

I did have to remove the test_entities_search_all_call because it was literally pulling back the entire Thesaurus and then filtering, which overwhelms the system.  I am putting in a ticket to prevent users from doing this. 
